### PR TITLE
 Fix UnboundLocalError in generate_llm_compiler_prompt function

### DIFF
--- a/src/llm_compiler/planner.py
+++ b/src/llm_compiler/planner.py
@@ -50,7 +50,7 @@ def generate_llm_compiler_prompt(
         prefix += f"{i+1}. {tool.description}\n"
 
     # Join operation
-    prefix += f"{i+2}. {JOIN_DESCRIPTION}\n\n"
+    prefix += f"{len(tools)+1}. {JOIN_DESCRIPTION}\n\n"
 
     # Guidelines
     prefix += (


### PR DESCRIPTION
This PR resolves an `UnboundLocalError` that occurred when referencing `i` outside its scope in the `generate_llm_compiler_prompt` function. Instead of relying on `i` from the loop, which could be undefined if `tools` is empty, we now use `len(tools)` directly to add the `JOIN_DESCRIPTION`. 